### PR TITLE
hotfix: removendo use / para get

### DIFF
--- a/src/infrastructure/http/Server.ts
+++ b/src/infrastructure/http/Server.ts
@@ -28,7 +28,7 @@ export class Server {
 
         this._app.use(cors())
 
-        this._app.use("/", (req, res) => {res.send("teste")})
+        this._app.get("/", (req, res) => {res.send("teste")})
 
         this._app.use("/user", userRouter)
 


### PR DESCRIPTION
resolvendo a questão do use("/") está "roubando" todos as requisições, agora ele volta a ser get 